### PR TITLE
Fix infinite height BoxConstraints in scroll views

### DIFF
--- a/lib/layouts/auth_layout.dart
+++ b/lib/layouts/auth_layout.dart
@@ -69,7 +69,9 @@ class _AuthLayoutState extends State<AuthLayout> {
                       builder: (context, constraints) {
                         return SingleChildScrollView(
                           child: ConstrainedBox(
-                            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                            constraints: constraints.maxHeight.isFinite
+                                ? BoxConstraints(minHeight: constraints.maxHeight)
+                                : const BoxConstraints(),
                             child: IntrinsicHeight(
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/screens/dashboard/transactions/transaction_form_screen.dart
+++ b/lib/screens/dashboard/transactions/transaction_form_screen.dart
@@ -90,7 +90,9 @@ class _TransactionFormScreenState extends State<TransactionFormScreen> {
         builder: (context, constraints) {
           return SingleChildScrollView(
             child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              constraints: constraints.maxHeight.isFinite
+                  ? BoxConstraints(minHeight: constraints.maxHeight)
+                  : const BoxConstraints(),
               child: Container(
                 width: double.infinity,
                 padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- avoid infinite height in `AuthLayout` when maxHeight is unbounded
- handle unbounded constraints in `TransactionFormScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac54285b608328b25bd0456ab92229